### PR TITLE
Fixed modernity issues with 1.9 and dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,15 +1,15 @@
-(defproject freactive.core "0.2.0-SNAPSHOT"
+(defproject freactive.core "0.2.1-SNAPSHOT"
   :description "Generic reactive atoms, expressions, cursors"
   :url "https://github.com/aaronc/freactive.core"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies
-  [[org.clojure/clojure "1.7.0-RC1"]
-   [org.clojure/data.avl "0.0.12"]]
+  [[org.clojure/clojure "1.9.0"]
+   [org.clojure/data.avl "0.0.17"]]
   :profiles
   {:dev
    {:dependencies 
-    [[org.clojure/clojurescript "0.0-3269"]]}}
+    [[org.clojure/clojurescript "1.10.238"]]}}
   :source-paths ["src/clojure"]
   :javac-options ["-Xlint:unchecked"]
   :java-source-paths ["src/java"])

--- a/src/clojure/freactive/core.cljc
+++ b/src/clojure/freactive/core.cljc
@@ -769,12 +769,12 @@ using the lens-cursor function."
 
      (defmacro reactive [& body]
        `(freactive.core/reactive*
-         (fn reactive-computation-fn []
+         (fn ~'reactive-computation-fn []
            ~@body)))
 
      (defmacro eager-reactive [& body]
        `(freactive.core/eager-reactive*
-         (fn reactive-computation-fn []
+         (fn ~'reactive-computation-fn []
            ~@body)))
 
      (def rx* reactive*)


### PR DESCRIPTION
Updated clojure dep to 1.9, and fixed a subsequent
error within the reactive macro definitions that
spec found.  Turns out, the name-symbols for the
anonymous functions weren't actually quoted...
so the actual ns-qualified var was being used
and causing a problem!  Fix was to quote said
symbols inside the macros.

Also updated data.avl dep to latest public
release 0.0.17 just because.